### PR TITLE
This prevents the toolbar from being added to json requests for example.

### DIFF
--- a/Classes/Debug/Toolbar/Http/RequestHandler.php
+++ b/Classes/Debug/Toolbar/Http/RequestHandler.php
@@ -63,7 +63,11 @@ class RequestHandler extends \TYPO3\Flow\Http\RequestHandler {
 		\Debug\Toolbar\Toolbar\View::handleRedirects($this->request, $this->response);
 		$this->emitAboutToRenderDebugToolbar();
 		\Debug\Toolbar\Service\DataStorage::set('Modules', \Debug\Toolbar\Service\Collector::getModules());
-		echo \Debug\Toolbar\Toolbar\View::attachToolbar($this->response->getContent());
+		if ($actionRequest->getFormat() === 'html') {
+			echo \Debug\Toolbar\Toolbar\View::attachToolbar($this->response->getContent());
+		} else {
+			echo $this->response->getContent();
+		}
 		$this->bootstrap->shutdown('Runtime');
 		$this->exit->__invoke();
 		\Debug\Toolbar\Service\DataStorage::save();


### PR DESCRIPTION
This prevents the toolbar from being added to json requests for example.
