### PR TITLE
[BUGFIX] Fatal Error mismatch between ClassName and FileName

### DIFF
--- a/Classes/Debug/Toolbar/Debugger/AopDebugger.php
+++ b/Classes/Debug/Toolbar/Debugger/AopDebugger.php
@@ -16,7 +16,7 @@ use TYPO3\Flow\Annotations as Flow;
 /**
  * @Flow\Scope("singleton")
  */
-class AOPDebugger {
+class AopDebugger {
 
 	/**
 	 * @var \TYPO3\Flow\Reflection\ReflectionService


### PR DESCRIPTION
This simple Rename of the class resolves the Problem with filename
classname mismatch.

Resolves: #16
